### PR TITLE
Avoid problems with offline usage

### DIFF
--- a/opencc.js
+++ b/opencc.js
@@ -1,7 +1,10 @@
 'use strict';
 
-if (typeof window === 'undefined')
-	var fetch = require('node-fetch');
+if (typeof window === 'undefined') {
+	var fs = require('fs');
+	var util = require('util');
+	var readFilePromise = util.promisify(fs.readFile);
+}
 
 const OpenCC = {
 	/* Trie */
@@ -74,11 +77,19 @@ const OpenCC = {
 			, "jp": ["JPVariants"]
 			};
 
+		async function getDictTextNode(url) {
+		    const pathName = require.resolve('opencc-data/data/' + url + '.txt');
+		    const response = await readFilePromise(pathName);
+		    return response.toString();
+		}
+
 		async function getDictText(url) {
 			const response = await fetch(DICT_ROOT + url + '.txt');
 			const text = await response.text();
 			return text;
 		}
+
+		const getDict = (typeof window === 'undefined') ? getDictTextNode : getDictText;
 
 		let DICTS;
 		if (type == 'from')
@@ -87,7 +98,7 @@ const OpenCC = {
 			DICTS = DICT_TO[s];
 		const t = OpenCC._makeEmptyTrie();
 		for (const DICT of DICTS) {
-			const txt = await getDictText(DICT);
+			const txt = await getDict(DICT);
 			const lines = txt.split('\n');
 			for (const line of lines) {
 				if (line && !line.startsWith('#')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    "opencc-data": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/opencc-data/-/opencc-data-1.0.3.tgz",
+      "integrity": "sha1-3K/lZGpja+2lPQ5YGf3JmtKCup4="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "homepage": "https://github.com/nk2028/opencc-js#readme",
   "dependencies": {
-    "node-fetch": "^2.6.0"
+    "opencc-data": "^1.0.3"
   }
 }


### PR DESCRIPTION
- When using opencc-js while not connected to a network, the fetch of the txt data fails. Depending on opencc-data for the node
implementation avoids that problem
- If your machine doesn't have the right certificate authorities, then using fetch to get things on cdn.jsdelivr.net will fail with an exception. Using local data files avoids that problem.
- Loading local files is faster than downloading over the internet