### PR TITLE
Properly detect node environment

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 'use strict';
 
-if (typeof window === 'undefined') {
+const ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function';
+
+if (ENVIRONMENT_IS_NODE) {
 	var fs = require('fs');
 	var util = require('util');
 	var readFilePromise = util.promisify(fs.readFile);
@@ -58,7 +60,7 @@ const OpenCC = {
 			return text;
 		}
 
-		const getDict = (typeof window === 'undefined') ? getDictTextNode : getDictText;
+		const getDict = ENVIRONMENT_IS_NODE ? getDictTextNode : getDictText;
 
 		let DICTS;
 		if (type === 'from') {


### PR DESCRIPTION
Current implementation detects node environment by checking if `window` is undefined but it fails at case of web workers.
I copied the implementation [from emscripten.](https://github.com/emscripten-core/emscripten/blob/54b0f19d9e8130de16053b0915d114c346c99f17/src/shell.js#L37), which checks existances of node-specific classes.