### PR TITLE
README.md shorter working + inline comments when possible.

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -56,7 +56,7 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 **DOM 操作**
 
 ```html
-<span lang="zh-HK">繁體中文</span>
+<span lang="zh-HK">漢語</span>
 ```
 
 ```javascript
@@ -66,10 +66,8 @@ const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });
 const rootNode = document.documentElement;
 // 将所有 zh-HK 标签转为 zh-CN 标签
 const HTMLConvertHandler = OpenCC.HTMLConverter(converter, rootNode, 'zh-HK', 'zh-CN');
-// 开始转换
-HTMLConvertHandler.convert();
-// 复原
-HTMLConvertHandler.restore();
+HTMLConvertHandler.convert();// 开始转换  -> 汉语 
+HTMLConvertHandler.restore();// 复原     -> 漢語
 ```
 
 class list 包含 `ignore-opencc` 的标签不会被转换（包括该标签的所有子节点）。

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -9,14 +9,10 @@
 依次加载以下四个 `script` 标签：
 
 ```html
-<!-- 下面一条必须加载 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.min.js"></script>
-<!-- 不需要简转繁时，可删除下面一条，以加快加载 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.cn2t.min.js"></script>
-<!-- 不需要繁转简时，可删除下面一条，以加快加载 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.t2cn.min.js"></script>
-<!-- 下面一条必须加载 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/bundle-browser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.min.js"></script>        <!-- 必须加载 -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.cn2t.min.js"></script>    <!-- 需要简转繁时 -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.t2cn.min.js"></script>    <!-- 需要繁转简时 -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/bundle-browser.min.js"></script><!-- 必须加载 -->
 ```
 
 **在 Node.js 中加载**
@@ -41,7 +37,7 @@ console.log(converter('漢字，簡體字')); // output: 汉字，简体字
 
 - `cn`: 简体中文（中国大陆）
 - `tw`: 繁体中文（台湾）
-- `twp`: 繁体中文（台湾，且转换词汇）
+  - `twp`: 繁体中文（台湾，且转换词汇）
 - `hk`: 繁体中文（香港）
 - `jp`: 日本新字体
 - `t`: 繁体中文（OpenCC 标准。除非你知道自己在做什么，否则请勿使用）
@@ -58,6 +54,10 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 ```
 
 **DOM 操作**
+
+```html
+<span lang="zh-HK">繁體中文</span>
+```
 
 ```javascript
 // 将繁体中文（香港）转换为简体中文（中国大陆）

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -9,14 +9,10 @@
 依次載入以下四個 `script` 標籤：
 
 ```html
-<!-- 下面一條必須載入 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.min.js"></script>
-<!-- 不需要簡轉繁時，可刪除下面一條，以加快載入 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.cn2t.min.js"></script>
-<!-- 不需要繁轉簡時，可刪除下面一條，以加快載入 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.t2cn.min.js"></script>
-<!-- 下面一條必須載入 -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/bundle-browser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.min.js"></script>          <!-- 必須載入 -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.cn2t.min.js"></script>     <!-- 需要簡轉繁時 -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.t2cn.min.js"></script>     <!-- 需要繁轉簡時 -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/bundle-browser.min.js"></script><!-- 必須載入 -->
 ```
 
 **在 Node.js 中載入**
@@ -41,7 +37,7 @@ console.log(converter('漢字，簡體字')); // output: 汉字，简体字
 
 - `cn`: 簡體中文（中國大陸）
 - `tw`: 繁體中文（臺灣）
-- `twp`: 繁體中文（臺灣，且轉換詞彙）
+  - `twp`: 繁體中文（臺灣，且轉換詞彙）
 - `hk`: 繁體中文（香港）
 - `jp`: 日本新字體
 - `t`: 繁體中文（OpenCC 標準。除非你知道自己在做什麼，否則請勿使用）
@@ -59,6 +55,9 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 
 **DOM 操作**
 
+```html
+<span lang="zh-HK">繁體中文</span>
+```
 ```javascript
 // 將繁體中文（香港）轉換為簡體中文（中國大陸）
 const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });
@@ -66,10 +65,8 @@ const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });
 const rootNode = document.documentElement;
 // 將所有 zh-HK 標籤轉為 zh-CN 標籤
 const HTMLConvertHandler = OpenCC.HTMLConverter(converter, rootNode, 'zh-HK', 'zh-CN');
-// 開始轉換
-HTMLConvertHandler.convert();
-// 復原
-HTMLConvertHandler.restore();
+HTMLConvertHandler.convert(); // 開始轉換  -> 繁体中文 
+HTMLConvertHandler.restore(); // 復原     -> 繁體中文
 ```
 
 class list 包含 `ignore-opencc` 的標籤不會被轉換（包括該標籤的所有子節點）。

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -56,7 +56,7 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 **DOM 操作**
 
 ```html
-<span lang="zh-HK">繁體中文</span>
+<span lang="zh-HK">漢語</span>
 ```
 ```javascript
 // 將繁體中文（香港）轉換為簡體中文（中國大陸）
@@ -65,8 +65,8 @@ const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });
 const rootNode = document.documentElement;
 // 將所有 zh-HK 標籤轉為 zh-CN 標籤
 const HTMLConvertHandler = OpenCC.HTMLConverter(converter, rootNode, 'zh-HK', 'zh-CN');
-HTMLConvertHandler.convert(); // 開始轉換  -> 繁体中文 
-HTMLConvertHandler.restore(); // 復原     -> 繁體中文
+HTMLConvertHandler.convert(); // 開始轉換  -> 汉语 
+HTMLConvertHandler.restore(); // 復原     -> 漢語
 ```
 
 class list 包含 `ignore-opencc` 的標籤不會被轉換（包括該標籤的所有子節點）。

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ console.log(converter('漢字，簡體字')); // output: 汉字，简体字
 
 - `cn`: Simplified Chinese (Mainland China)
 - `tw`: Traditional Chinese (Taiwan)
-- `twp`: Traditional Chinese (Taiwan, with phrase conversion)
+  - `twp`: Traditional Chinese (Taiwan, with phrase conversion)
 - `hk`: Traditional Chinese (Hong Kong)
 - `jp`: Japanese Shinjitai
 - `t`: Traditional Chinese (OpenCC standard. Do not use unless you know what you are doing)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 **DOM operations**
 
 ```html
-<span lang="zh-HK">繁體中文</span>
+<span lang="zh-HK">漢語</span>
 ```
 
 ```javascript
@@ -68,8 +68,8 @@ const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });
 const rootNode = document.documentElement;
 // Convert all zh-HK tags to zh-CN tags
 const HTMLConvertHandler = OpenCC.HTMLConverter(converter, rootNode, 'zh-HK', 'zh-CN');
-HTMLConvertHandler.convert();  // Start conversion
-HTMLConvertHandler.restore();  // Restore
+HTMLConvertHandler.convert();  // Convert  -> 汉语
+HTMLConvertHandler.restore();  // Restore  -> 漢語
 ```
 
 All the tags which contains `ignore-opencc` in the class list will not be converted (including all sub-nodes of the tags).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 
 **DOM operations**
 
+```html
+<span lang="zh-HK">繁體中文</span>
+```
+
 ```javascript
 // Set Chinese convert from Traditional (Hong Kong) to Simplified (Mainland China)
 const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });

--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@ The JavaScript version of Open Chinese Convert (OpenCC)
 Load the following four `script` tags in sequence:
 
 ```html
-<!-- The following one is required -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.min.js"></script>
-<!-- The following one can be removed for speed if you do not need to convert from Simplified Chinese to Traditional Chinese -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.cn2t.min.js"></script>
-<!-- The following one can be removed for speed if you do not need to convert from Traditional Chinese to Simplified Chinese -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.t2cn.min.js"></script>
-<!-- The following one is required -->
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/bundle-browser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.min.js"></script>            <!-- Required -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.cn2t.min.js"></script>       <!-- For Simplified to Traditional -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/data.t2cn.min.js"></script>       <!-- For Traditional Chinese to Simplified Chinese -->
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.1/bundle-browser.min.js"></script>  <!-- Required -->
 ```
 
 **Import opencc-js in Node.js**
@@ -62,16 +58,14 @@ console.log(converter('香蕉 蘋果 梨')); // output: banana apple pear
 **DOM operations**
 
 ```javascript
-// Convert Traditional Chinese (Hong Kong) to Simplified Chinese (Mainland China)
+// Set Chinese convert from Traditional (Hong Kong) to Simplified (Mainland China)
 const converter = OpenCC.Converter({ from: 'hk', to: 'cn' });
 // Set the conversion starting point to the root node, i.e. convert the whole page
 const rootNode = document.documentElement;
 // Convert all zh-HK tags to zh-CN tags
 const HTMLConvertHandler = OpenCC.HTMLConverter(converter, rootNode, 'zh-HK', 'zh-CN');
-// Start conversion
-HTMLConvertHandler.convert();
-// Restore
-HTMLConvertHandler.restore();
+HTMLConvertHandler.convert();  // Start conversion
+HTMLConvertHandler.restore();  // Restore
 ```
 
 All the tags which contains `ignore-opencc` in the class list will not be converted (including all sub-nodes of the tags).


### PR DESCRIPTION
Concise comments approach when possible.
Inline comments approach when possible.
Aligned en, cn, tw.
Added the `HTML attribute lang`, which is a core part of your system for browsers.
Switched to example 漢語 -> 汉语.