### PR TITLE
fix type error

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,7 +52,7 @@ export class Trie {
    * 根據字典樹中的資料轉換字串。
    * @param {string} s 要轉換的字串
    */
-  convert(s) {
+  convert(s = '') {
     const t = this.map;
     const n = s.length, arr = [];
     let orig_i;


### PR DESCRIPTION
```
webpack-internal:///./node_modules/opencc-js/bundle-node.js:97
      const n = s.length, arr = [];
                  ^

TypeError: Cannot read properties of undefined (reading 'length')
    at Trie.convert (webpack-internal:///./node_modules/opencc-js/bundle-node.js:97:19)
    at convert (webpack-internal:///./node_modules/opencc-js/bundle-node.js:170:48)
    at pushRssToChannel (webpack-internal:///./src/news/pushRssToChannel.ts:31:39)
    at eval (webpack-internal:///./src/bot/botStart.ts:51:52)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
[nodemon] app crashed - waiting for file changes before starting...
```