### PR TITLE
Fix CI workflow and Node version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,13 +8,11 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14
+        node-version: 20.x
         registry-url: https://registry.npmjs.org/
-    - name: Install bundler
-      run: npm install -g rollup
     - name: Install dependencies
       run: npm ci
     - name: Build & Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14.x
-    - name: Install bundler
-      run: npm install -g rollup
+        node-version: 20.x
     - name: Install dependencies
       run: npm ci
     - name: Build & Test

--- a/buildAndTest.sh
+++ b/buildAndTest.sh
@@ -2,17 +2,5 @@
 
 set -e
 
-# Build
-
-node build.js
-
-npx rollup -c
-
-# Test
-
-node test/node/basic.mjs
-node test/node/basic.cjs
-
-wget -nc -nv -P test https://raw.githubusercontent.com/weiyinfu/JinYong/db1d9a9/%E9%87%91%E5%BA%B8%E5%85%A8%E9%9B%86%E4%B8%89%E8%81%94%E7%89%88/%E7%A5%9E%E9%9B%95%E4%BE%A0%E4%BE%A3.txt
-wget -nc -nv -P test https://raw.githubusercontent.com/weiyinfu/JinYong/db1d9a9/%E9%87%91%E5%BA%B8%E5%85%A8%E9%9B%86%E4%B8%89%E8%81%94%E7%89%88/%E5%A4%A9%E9%BE%99%E5%85%AB%E9%83%A8.txt
-node test/node/speed.cjs
+npm run build
+npm test


### PR DESCRIPTION
Use Node 20 with current checkout/setup-node actions, rely on project-local build tooling, and remove the flaky external speed-test downloads from the mandatory build script.