### PR TITLE
Prepare `1.3.1-next.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 1.3.1-next.1 - 2026-05-03
 
 ### Added
 
-- Add `THIRD_PARTY_LICENSES.md` documenting the use of `opencc-data` (Apache 2.0) and include it in the published package.
 - Add OpenCC-style mmseg segmentation for built-in converters so multi-stage conversions preserve official phrase boundaries.
-- Add default ESM exports for the bundled package entry points.
-- Add TypeScript declaration files for the public package entry points.
 - Add explicit package exports for `opencc-js/core`, `opencc-js/preset`, `opencc-js/preset/cn2t`, and `opencc-js/preset/t2cn`.
 - Add CommonJS conditional exports for `opencc-js/cn2t` and `opencc-js/t2cn`.
+- Add default ESM exports for the bundled package entry points.
+- Add TypeScript declaration files for the public package entry points.
+- Add `THIRD_PARTY_LICENSES.md` documenting the use of `opencc-data` (Apache 2.0) and include it in the published package.
 
 ### Changed
 

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -157,10 +157,12 @@ console.log(converter('漢語'));
 
 ## 与 [`opencc`](https://www.npmjs.com/package/opencc) npm package 的区别
 
-[`opencc`](https://www.npmjs.com/package/opencc) npm package 是官方 OpenCC C++ 项目的 Node.js native binding，主要用于 Node.js，依赖 native 或 prebuilt binary，并跟随官方 OpenCC 引擎。
-
 [`opencc-js`](https://www.npmjs.com/package/opencc-js) npm package 是面向浏览器和 Node.js 的纯 JavaScript 实现。它打包了从 `opencc-data` 生成的字典数据，因此不需要 native binary，也不会在运行时下载字典 txt 文件。
 
-[`opencc-js`](https://www.npmjs.com/package/opencc-js) 不是官方 C++ OpenCC 算法的完整移植。它使用 JavaScript trie 和字典 pipeline，并通过 upstream OpenCC test cases 验证，但不应视为对所有输入都与官方 OpenCC bit-for-bit 等价。
+[`opencc-js`](https://www.npmjs.com/package/opencc-js) 的转换流程已向官方 OpenCC 实现对齐，包括内置转换器的词组分词，并通过 upstream OpenCC test cases 和 golden outputs 验证。但它仍不保证对所有输入都与官方 OpenCC 产生 100% 相同的结果。
 
-[`opencc-wasm`](https://www.npmjs.com/package/opencc-wasm) npm package 是另一个能在浏览器中使用的实现。它使用 WebAssembly，配置和转换逻辑与官方 [`opencc`](https://www.npmjs.com/package/opencc) package 对齐。
+`opencc-js` 目前支持内置转换器使用的 OpenCC mmseg 风格分词，但不支持 jieba 等扩展分词算法。
+
+[`opencc`](https://www.npmjs.com/package/opencc) npm package 是官方 OpenCC C++ 项目的 Node.js native binding，主要用于 Node.js，依赖 native 或 prebuilt binary，并跟随官方 OpenCC 引擎。在官方 OpenCC 配置和运行环境支持时，它可以使用 jieba 等扩展分词算法。
+
+[`opencc-wasm`](https://www.npmjs.com/package/opencc-wasm) npm package 是另一个能在浏览器中使用的实现。它使用 WebAssembly，配置和转换逻辑与官方 [`opencc`](https://www.npmjs.com/package/opencc) package 对齐，并可通过官方 OpenCC runtime 支持 jieba 分词。

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -157,10 +157,12 @@ console.log(converter('漢語'));
 
 ## 與 [`opencc`](https://www.npmjs.com/package/opencc) npm package 的區別
 
-[`opencc`](https://www.npmjs.com/package/opencc) npm package 是官方 OpenCC C++ 專案的 Node.js native binding，主要用於 Node.js，依賴 native 或 prebuilt binary，並跟隨官方 OpenCC 引擎。
-
 [`opencc-js`](https://www.npmjs.com/package/opencc-js) npm package 是面向瀏覽器和 Node.js 的純 JavaScript 實作。它打包了從 `opencc-data` 產生的字典資料，因此不需要 native binary，也不會在執行時下載字典 txt 檔案。
 
-[`opencc-js`](https://www.npmjs.com/package/opencc-js) 不是官方 C++ OpenCC 演算法的完整移植。它使用 JavaScript trie 和字典 pipeline，並通過 upstream OpenCC test cases 驗證，但不應視為對所有輸入都與官方 OpenCC bit-for-bit 等價。
+[`opencc-js`](https://www.npmjs.com/package/opencc-js) 的轉換流程已向官方 OpenCC 實作對齊，包括內建轉換器的詞組分詞，並通過 upstream OpenCC test cases 和 golden outputs 驗證。但它仍不保證對所有輸入都與官方 OpenCC 產生 100% 相同的結果。
 
-[`opencc-wasm`](https://www.npmjs.com/package/opencc-wasm) npm package 是另一個能在瀏覽器中使用的實作。它使用 WebAssembly，配置和轉換邏輯與官方 [`opencc`](https://www.npmjs.com/package/opencc) package 對齊。
+`opencc-js` 目前支援內建轉換器使用的 OpenCC mmseg 風格分詞，但不支援 jieba 等擴充分詞演算法。
+
+[`opencc`](https://www.npmjs.com/package/opencc) npm package 是官方 OpenCC C++ 專案的 Node.js native binding，主要用於 Node.js，依賴 native 或 prebuilt binary，並跟隨官方 OpenCC 引擎。在官方 OpenCC 設定和執行環境支援時，它可以使用 jieba 等擴充分詞演算法。
+
+[`opencc-wasm`](https://www.npmjs.com/package/opencc-wasm) npm package 是另一個能在瀏覽器中使用的實作。它使用 WebAssembly，配置和轉換邏輯與官方 [`opencc`](https://www.npmjs.com/package/opencc) package 對齊，並可透過官方 OpenCC runtime 支援 jieba 分詞。

--- a/README.md
+++ b/README.md
@@ -8,38 +8,52 @@ Dictionary data is generated from `opencc-data` at build time and bundled in the
 
 ## Import
 
-**Import opencc-js in HTML page**
-
-Import in HTML pages:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.3.0/dist/umd/full.js"></script>     <!-- Full version -->
-```
-
-ES6 import
-
-```html
-<script type="module">
-  import OpenCC from './dist/esm/full.js'; // Full version
-</script>
-```
-
-**Import opencc-js in Node.js script**
+**Install opencc-js for Node.js or a bundler**
 
 ```sh
 npm install opencc-js
 ```
 
-CommonJS
+ES modules:
+
+```javascript
+import OpenCC from 'opencc-js';
+```
+
+CommonJS:
 
 ```javascript
 const OpenCC = require('opencc-js');
 ```
 
-ES Modules
+**Use opencc-js in a browser**
 
-```javascript
-import OpenCC from 'opencc-js';
+Self-hosted ES module:
+
+```html
+<script type="module">
+  import OpenCC from './dist/esm/full.js';
+
+  const converter = OpenCC.Converter({ from: 'cn', to: 'tw' });
+  console.log(converter('汉语'));
+</script>
+```
+
+CDN ES module:
+
+```html
+<script type="module">
+  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.3.1-next.1/dist/esm/full.js';
+
+  const converter = OpenCC.Converter({ from: 'cn', to: 'tw' });
+  console.log(converter('汉语'));
+</script>
+```
+
+UMD build for plain script tags:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.3.1-next.1/dist/umd/full.js"></script>
 ```
 
 ## Usage
@@ -128,10 +142,10 @@ HTMLConvertHandler.restore(); // Restore  -> 漢語
 ```
 
 ## API
-* `.Converter({})`: declare the converter's direction via locals.
+* `.Converter({})`: declare the converter's direction via locales.
   * default: `{ from: 'tw', to: 'cn' }`
-  * syntax : `{ from: local1, to: local2 }`
-* locals: letter codes defining a writing local tradition, occasionally its idiomatic habits.
+  * syntax : `{ from: locale1, to: locale2 }`
+* locales: letter codes defining a writing locale and, occasionally, its idiomatic habits.
   * `cn`: Simplified Chinese (Mainland China)
   * `tw`: Traditional Chinese (Taiwan)
     * `twp`: with phrase conversion (ex: 自行車 -> 腳踏車）
@@ -141,7 +155,7 @@ HTMLConvertHandler.restore(); // Restore  -> 漢語
 * `.CustomConverter([])` : defines custom dictionary.
   * default: `[]`
   * syntax : `[  ['item1','replacement1'], ['item2','replacement2'], … ]`
-* `.HTMLConverter(converter, rootNode, langAttrInitial, langAttrNew )` : uses previously defined converter() to converts all HTML elements text content from a starting root node and down, into the target local. Also converts all attributes `lang` from existing `langAttrInitial` to `langAttrNew` values, and converts `placeholder` and `aria-label` attributes.
+* `.HTMLConverter(converter, rootNode, langAttrInitial, langAttrNew )` : uses previously defined converter() to convert all HTML elements text content from a starting root node and down, into the target locale. Also converts all attributes `lang` from existing `langAttrInitial` to `langAttrNew` values, and converts `placeholder` and `aria-label` attributes.
 * `lang` attributes : html attribute defines the languages of the text content to the browser, at start (`langAttrInitial`) and after conversion (`langAttrNew`).
   * syntax convention: [IETF languages codes](https://www.w3.org/International/articles/bcp47/#macro), mainly `zh-TW`, `zh-HK`, `zh-CN`, `zh-SG`,…
 * `ignore-opencc` : html class signaling an element and its sub-nodes will not be converted.
@@ -162,10 +176,12 @@ console.log(converter('漢語'));
 
 ## Difference from the [`opencc`](https://www.npmjs.com/package/opencc) npm package
 
-The [`opencc`](https://www.npmjs.com/package/opencc) npm package is the Node.js native binding for the official OpenCC C++ project. It is intended for Node.js, depends on native or prebuilt binaries, and follows the official OpenCC engine.
-
 The [`opencc-js`](https://www.npmjs.com/package/opencc-js) npm package is a pure JavaScript implementation for browsers and Node.js. It bundles dictionary data generated from `opencc-data`, so it does not require native binaries and does not fetch dictionary text files at runtime.
 
-[`opencc-js`](https://www.npmjs.com/package/opencc-js) is not a complete port of the official C++ OpenCC algorithm. It uses a JavaScript trie and dictionary pipeline, and is tested against upstream OpenCC test cases, but it should not be treated as bit-for-bit equivalent for every possible input.
+[`opencc-js`](https://www.npmjs.com/package/opencc-js) has aligned its conversion flow with the official OpenCC implementation, including phrase segmentation for built-in converters, and is tested against upstream OpenCC test cases and golden outputs. It still should not be treated as guaranteed to produce 100% identical results for every possible input.
 
-The [`opencc-wasm`](https://www.npmjs.com/package/opencc-wasm) npm package is another browser-capable implementation. It uses WebAssembly and keeps its configuration and conversion logic aligned with the official [`opencc`](https://www.npmjs.com/package/opencc) package.
+`opencc-js` currently supports the built-in OpenCC mmseg-style segmentation used by its bundled converters, but it does not support extended segmentation algorithms such as Jieba.
+
+The [`opencc`](https://www.npmjs.com/package/opencc) npm package is the Node.js native binding for the official OpenCC C++ project. It is intended for Node.js, depends on native or prebuilt binaries, and follows the official OpenCC engine. It can use extended segmentation algorithms such as Jieba when supported by the official OpenCC configuration and runtime.
+
+The [`opencc-wasm`](https://www.npmjs.com/package/opencc-wasm) npm package is another browser-capable implementation. It uses WebAssembly, keeps its configuration and conversion logic aligned with the official [`opencc`](https://www.npmjs.com/package/opencc) package, and can support Jieba segmentation through the official OpenCC runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencc-js",
-  "version": "1.3.1-dev.0",
+  "version": "1.3.1-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencc-js",
-      "version": "1.3.1-dev.0",
+      "version": "1.3.1-next.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencc-js",
-  "version": "1.3.1-dev.0",
+  "version": "1.3.1-next.1",
   "description": "The JavaScript version of Open Chinese Convert (OpenCC)",
   "main": "./dist/umd/full.js",
   "types": "./types/full.d.ts",


### PR DESCRIPTION
Bump the package version to `1.3.1-next.1` after release-standard verification.

Rewrote README import examples to lead with modern ESM usage, fix locale terminology, and clarify how `opencc-js` differs from official OpenCC bindings and `opencc-wasm` around conversion parity and Jieba segmentation support.