### PR TITLE
Prepare release 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.4.2 - 2026-08-22
+
+### Changed
+
+- Align with upstream `opencc-data` 1.4.2 and refresh the generated dictionary data, including Taiwan 樑/梁 personal-name entries, 么/麼 and 雇/僱 variant mappings, 乾/干 phrase corrections, and additional regional phrases. See the upstream [OpenCC 1.4.2 release notes](https://github.com/BYVoid/OpenCC/blob/master/NEWS.md#version-142) for the detailed dictionary changes.
+
 ## 1.4.1 - 2026-07-12
 
 ### Changed

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -26,7 +26,7 @@
 
 请选择适合当前环境的安装或加载方式。
 
-> **重要：** 版本 `1.4.1` 同步 `opencc-data` 1.4.1，并刷新生成的字典数据。
+> **重要：** 版本 `1.4.2` 同步 `opencc-data` 1.4.2，并刷新生成的字典数据。
 
 **为 Node.js 或 bundler 安装 opencc-js**
 
@@ -63,8 +63,8 @@ CDN ES module:
 
 ```html
 <script type="module">
-  // 请使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明确固定 1.4.1
-  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.4.1/dist/esm/full.js';
+  // 请使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明确固定 1.4.2
+  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.4.2/dist/esm/full.js';
 
   const converter = OpenCC.Converter({ from: 'cn', to: 'tw' });
   console.log(converter('汉语')); // 漢語
@@ -74,9 +74,9 @@ CDN ES module:
 用于普通 script 标签的 UMD build:
 
 ```html
-<!-- 请使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明确固定 1.4.1 -->
+<!-- 请使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明确固定 1.4.2 -->
 
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.4.1/dist/umd/full.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.4.2/dist/umd/full.js"></script>
 ```
 
 **基本用法**

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -26,7 +26,7 @@
 
 請選擇適合目前環境的安裝或載入方式。
 
-> **重要：** 版本 `1.4.1` 同步 `opencc-data` 1.4.1，並刷新產生的字典資料。
+> **重要：** 版本 `1.4.2` 同步 `opencc-data` 1.4.2，並刷新產生的字典資料。
 
 **為 Node.js 或 bundler 安裝 opencc-js**
 
@@ -63,8 +63,8 @@ CDN ES module:
 
 ```html
 <script type="module">
-  // 請使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明確固定 1.4.1
-  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.4.1/dist/esm/full.js';
+  // 請使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明確固定 1.4.2
+  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.4.2/dist/esm/full.js';
 
   const converter = OpenCC.Converter({ from: 'cn', to: 'tw' });
   console.log(converter('汉语')); // 漢語
@@ -74,9 +74,9 @@ CDN ES module:
 用於普通 script 標籤的 UMD build:
 
 ```html
-<!-- 請使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明確固定 1.4.1 -->
+<!-- 請使用 https://www.npmjs.com/package/opencc-js 上的最新 stable 版本，或明確固定 1.4.2 -->
 
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.4.1/dist/umd/full.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.4.2/dist/umd/full.js"></script>
 ```
 
 **基本用法**

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To avoid producing tofu boxes for glyphs that are often missing from browser and
 
 Choose the installation method that matches your environment.
 
-> **Important:** Version `1.4.1` syncs with `opencc-data` 1.4.1 and refreshes the generated dictionary data.
+> **Important:** Version `1.4.2` syncs with `opencc-data` 1.4.2 and refreshes the generated dictionary data.
 
 **Install opencc-js for Node.js or a bundler**
 
@@ -63,8 +63,8 @@ CDN ES module:
 
 ```html
 <script type="module">
-  // Use the latest stable version from https://www.npmjs.com/package/opencc-js, or pin 1.4.1 explicitly
-  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.4.1/dist/esm/full.js';
+  // Use the latest stable version from https://www.npmjs.com/package/opencc-js, or pin 1.4.2 explicitly
+  import OpenCC from 'https://cdn.jsdelivr.net/npm/opencc-js@1.4.2/dist/esm/full.js';
 
   const converter = OpenCC.Converter({ from: 'cn', to: 'tw' });
   console.log(converter('汉语')); // 漢語
@@ -74,9 +74,9 @@ CDN ES module:
 UMD build for plain script tags:
 
 ```html
-<!-- Use the latest stable version from https://www.npmjs.com/package/opencc-js, or pin 1.4.1 explicitly -->
+<!-- Use the latest stable version from https://www.npmjs.com/package/opencc-js, or pin 1.4.2 explicitly -->
 
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.4.1/dist/umd/full.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.4.2/dist/umd/full.js"></script>
 ```
 
 **Basic usage**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "opencc-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencc-js",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-terser": "^1.0.0",
         "chai": "~4.3.4",
         "jsonc-parser": "^3.3.1",
-        "opencc-data": "1.4.1",
+        "opencc-data": "1.4.2",
         "rollup-plugin-generate-package-json": "^3.2.0"
       }
     },
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/opencc-data": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/opencc-data/-/opencc-data-1.4.1.tgz",
-      "integrity": "sha512-+BjBNHebIG5a6QBK9VTwFKJkvwTv7+r4LS3LhUijjTaNQwfDFwvg64YpYTPYfH8izLaph1aSz6BfCZWk/9SArA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/opencc-data/-/opencc-data-1.4.2.tgz",
+      "integrity": "sha512-LdWjAZOoh9d1nkVj2zfFhYI8Ub41qhPdxEwVq3c/1KdA9azx4MJp2pXw+dCdngXZ63DorDWxDHVPB05ONoTVSA==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencc-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "The JavaScript version of Open Chinese Convert (OpenCC)",
   "main": "./dist/umd/full.js",
   "types": "./types/full.d.ts",
@@ -86,7 +86,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "chai": "~4.3.4",
     "jsonc-parser": "^3.3.1",
-    "opencc-data": "1.4.1",
+    "opencc-data": "1.4.2",
     "rollup-plugin-generate-package-json": "^3.2.0"
   }
 }


### PR DESCRIPTION
### Changed

- Align with upstream `opencc-data` 1.4.2 and refresh the generated dictionary data, including Taiwan 樑/梁 personal-name entries, 么/麼 and 雇/僱 variant mappings, 乾/干 phrase corrections, and additional regional phrases. See the upstream [OpenCC 1.4.2 release notes](https://github.com/BYVoid/OpenCC/blob/master/NEWS.md#version-142) for the detailed dictionary changes.