### PR TITLE
Fix identity-entry filter miscounting non-BMP characters as multi-char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Fix the dictionary build script incorrectly keeping redundant "character maps to itself" entries for characters outside the Basic Multilingual Plane (e.g. 𪙏), since `String.prototype.length` counts UTF-16 code units rather than code points. These entries are now correctly filtered out, slightly reducing dictionary size with no effect on conversion results. ([#49](https://github.com/nk2028/opencc-js/issues/49), reported by [@obxyann](https://github.com/obxyann), thanks!)
+
 ## 1.4.2 - 2026-08-22
 
 ### Changed

--- a/build.js
+++ b/build.js
@@ -126,7 +126,7 @@ function loadFile(fileName) {
   if (!fileContentCache[fileName]) {
     fileContentCache[fileName] = getEntries(fileName)
       .map(([k, values]) => [k, values[0]]) // only select the first candidate, the subsequent candidates are ignored
-      .filter(([k, v]) => k !== v || k.length > 1) // remove “char => the same char” convertions to reduce file size
+      .filter(([k, v]) => k !== v || [...k].length > 1) // remove “char => the same char” convertions to reduce file size
       .map(([k, v]) => k + ' ' + v)
       .join('|');
     const outputFile = getAbsPath(`./dist/esm-lib/dict/${fileName}.js`);


### PR DESCRIPTION
k.length counts UTF-16 code units, so a single character above U+FFFF (e.g. 𪙏) reports length 2 and its self-mapping entry survives the "char => same char" filter meant to trim redundant dictionary rows. Switch to a code-point count via [...k].length.

Fixes #49